### PR TITLE
telephony: Add oldril feature setPrefNwTypeOnUnsolConnected.

### DIFF
--- a/src/java/com/android/internal/telephony/RIL.java
+++ b/src/java/com/android/internal/telephony/RIL.java
@@ -3281,6 +3281,9 @@ public class RIL extends BaseCommands implements CommandsInterface {
 
                 // Initial conditions
                 setRadioPower(false, null);
+                if (needsOldRilFeature("setPrefNwTypeOnUnsolConnected")) {
+                    setPreferredNetworkType(mPreferredNetworkType, null);
+                }
                 setCdmaSubscriptionSource(mCdmaSubscription, null);
                 setCellInfoListRate(Integer.MAX_VALUE, null);
                 notifyRegistrantsRilConnectionChanged(((int[])ret)[0]);


### PR DESCRIPTION
  Commit 3feff8730f1de770131c984c5708a7da539943b6 removed
  the set nw mode on unsolicited connect which is causing
  data connection failures on certain devices.

Change-Id: I641841ba170a98f595e25516d01c0ff86ba17ff0